### PR TITLE
Fixed compilation errors under ROS Humble

### DIFF
--- a/scout_base/CMakeLists.txt
+++ b/scout_base/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(nav_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 find_package(scout_msgs REQUIRED)
 find_package(ugv_sdk REQUIRED)
@@ -41,6 +42,7 @@ set(DEPENDENCIES
   "std_msgs"
   "tf2"
   "tf2_ros"
+  "tf2_geometry_msgs"
   "scout_msgs"
   "sensor_msgs"
 )
@@ -57,7 +59,7 @@ add_executable(scout_base_node
     src/scout_base_ros.cpp
     src/scout_base_node.cpp)
 target_link_libraries(scout_base_node ugv_sdk)
-ament_target_dependencies(scout_base_node rclcpp tf2 tf2_ros std_msgs nav_msgs sensor_msgs scout_msgs)
+ament_target_dependencies(scout_base_node rclcpp tf2 tf2_ros tf2_geometry_msgs std_msgs nav_msgs sensor_msgs scout_msgs)
 
 install(TARGETS scout_base_node
   DESTINATION lib/${PROJECT_NAME})

--- a/scout_base/include/scout_base/scout_messenger.hpp
+++ b/scout_base/include/scout_base/scout_messenger.hpp
@@ -18,7 +18,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include "scout_msgs/msg/scout_status.hpp"
 #include "scout_msgs/msg/scout_light_cmd.hpp"

--- a/scout_base/src/scout_base_ros.cpp
+++ b/scout_base/src/scout_base_ros.cpp
@@ -15,17 +15,17 @@
 namespace westonrobot {
 ScoutBaseRos::ScoutBaseRos(std::string node_name)
     : rclcpp::Node(node_name), keep_running_(false) {
-  this->declare_parameter("port_name");
+  this->declare_parameter("port_name", "can0");
 
-  this->declare_parameter("odom_frame");
-  this->declare_parameter("base_frame");
-  this->declare_parameter("odom_topic_name");
+  this->declare_parameter("odom_frame", "odom");
+  this->declare_parameter("base_frame", "base_link");
+  this->declare_parameter("odom_topic_name", "odom");
 
-  this->declare_parameter("is_scout_mini");
-  this->declare_parameter("is_omni_wheel");
+  this->declare_parameter("is_scout_mini", false);
+  this->declare_parameter("is_omni_wheel", false);
 
-  this->declare_parameter("simulated_robot");
-  this->declare_parameter("control_rate");
+  this->declare_parameter("simulated_robot", false);
+  this->declare_parameter("control_rate", 50);
 
   LoadParameters();
 }


### PR DESCRIPTION
This PR contains a set of changes that enable the packages to compile under ROS Humble.

Summary of changes:
- Added `tf2_geometry_msgs` as an explicit dependency in `CMakeLists.txt` and changed the include statement in `scout_messenger.hpp` as `tf2_geometry_msgs.h` has been marked as obsolete.
- Fixed calls to `Node::declare_parameter` by adding a default value, using the same value as was already used in `ScoutBaseRos::LoadParameters`

Please let me know if you see any problems with any of the suggested changes.

Regards,
Valentin Veluppillai